### PR TITLE
[#29] プロンプト API を実装

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -4,12 +4,14 @@ import (
 	"database/sql"
 
 	authfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/auth"
+	promptfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt"
 	transcriptionfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription"
 	userfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/user"
 )
 
 type Container struct {
 	Auth          *authfeature.Feature
+	Prompt        *promptfeature.Feature
 	User          *userfeature.Feature
 	Transcription *transcriptionfeature.Feature
 }
@@ -17,10 +19,12 @@ type Container struct {
 func New(db *sql.DB, googleClientID string) *Container {
 	userFeature := userfeature.New(db)
 	authFeature := authfeature.New(googleClientID, userFeature.Repository)
+	promptFeature := promptfeature.New(db)
 	transcriptionFeature := transcriptionfeature.New(db)
 
 	return &Container{
 		Auth:          authFeature,
+		Prompt:        promptFeature,
 		User:          userFeature,
 		Transcription: transcriptionFeature,
 	}

--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -4,20 +4,24 @@ import (
 	"database/sql"
 
 	authfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/auth"
+	transcriptionfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription"
 	userfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/user"
 )
 
 type Container struct {
-	Auth *authfeature.Feature
-	User *userfeature.Feature
+	Auth          *authfeature.Feature
+	User          *userfeature.Feature
+	Transcription *transcriptionfeature.Feature
 }
 
 func New(db *sql.DB, googleClientID string) *Container {
 	userFeature := userfeature.New(db)
 	authFeature := authfeature.New(googleClientID, userFeature.Repository)
+	transcriptionFeature := transcriptionfeature.New(db)
 
 	return &Container{
-		Auth: authFeature,
-		User: userFeature,
+		Auth:          authFeature,
+		User:          userFeature,
+		Transcription: transcriptionFeature,
 	}
 }

--- a/backend/internal/feature/prompt/domain/prompt.go
+++ b/backend/internal/feature/prompt/domain/prompt.go
@@ -1,0 +1,46 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrNotFound  = errors.New("prompt not found")
+	ErrForbidden = errors.New("prompt forbidden")
+)
+
+type Prompt struct {
+	ID        int64
+	UserID    *int64
+	Name      string
+	Body      string
+	IsActive  bool
+	IsDefault bool
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (p *Prompt) OwnedBy(userID int64) bool {
+	return p.UserID != nil && *p.UserID == userID
+}
+
+type CreateParams struct {
+	UserID   int64
+	Name     string
+	Body     string
+	IsActive bool
+}
+
+type PatchParams struct {
+	Name     *string
+	Body     *string
+	IsActive *bool
+}
+
+type UpdateParams struct {
+	ID       int64
+	Name     string
+	Body     string
+	IsActive bool
+}

--- a/backend/internal/feature/prompt/domain/repository.go
+++ b/backend/internal/feature/prompt/domain/repository.go
@@ -1,0 +1,11 @@
+package domain
+
+import "context"
+
+type Repository interface {
+	ListVisibleByUserID(ctx context.Context, userID int64) ([]*Prompt, error)
+	Create(ctx context.Context, params CreateParams) (*Prompt, error)
+	FindByID(ctx context.Context, id int64) (*Prompt, error)
+	Update(ctx context.Context, params UpdateParams) (*Prompt, error)
+	Delete(ctx context.Context, id int64) error
+}

--- a/backend/internal/feature/prompt/handler/prompts.go
+++ b/backend/internal/feature/prompt/handler/prompts.go
@@ -1,0 +1,222 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	promptdomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/domain"
+	promptusecase "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/usecase"
+	"github.com/yoshioka0101/voiceblog/backend/internal/handler/middleware"
+)
+
+type Handler struct {
+	useCase *promptusecase.UseCase
+}
+
+type createRequest struct {
+	Name     string `json:"name" binding:"required"`
+	Body     string `json:"body" binding:"required"`
+	IsActive *bool  `json:"is_active"`
+}
+
+type updateRequest struct {
+	Name     *string `json:"name"`
+	Body     *string `json:"body"`
+	IsActive *bool   `json:"is_active"`
+}
+
+type response struct {
+	ID        int64  `json:"id"`
+	UserID    *int64 `json:"user_id"`
+	Name      string `json:"name"`
+	Body      string `json:"body"`
+	IsActive  bool   `json:"is_active"`
+	IsDefault bool   `json:"is_default"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+func NewHandler(useCase *promptusecase.UseCase) *Handler {
+	return &Handler{useCase: useCase}
+}
+
+func (h *Handler) RegisterProtectedRoutes(r gin.IRoutes) {
+	r.GET("/prompts", h.List)
+	r.POST("/prompts", h.Create)
+	r.PATCH("/prompts/:id", h.Update)
+	r.DELETE("/prompts/:id", h.Delete)
+}
+
+func (h *Handler) List(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	prompts, err := h.useCase.ListVisibleByUserID(c.Request.Context(), user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list prompts"})
+		return
+	}
+
+	responses := make([]response, 0, len(prompts))
+	for _, prompt := range prompts {
+		responses = append(responses, toResponse(prompt))
+	}
+
+	c.JSON(http.StatusOK, responses)
+}
+
+func (h *Handler) Create(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req createRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	name := strings.TrimSpace(req.Name)
+	body := strings.TrimSpace(req.Body)
+	if name == "" || body == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name and body are required"})
+		return
+	}
+
+	isActive := true
+	if req.IsActive != nil {
+		isActive = *req.IsActive
+	}
+
+	prompt, err := h.useCase.Create(c.Request.Context(), promptdomain.CreateParams{
+		UserID:   user.ID,
+		Name:     name,
+		Body:     body,
+		IsActive: isActive,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create prompt"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, toResponse(prompt))
+}
+
+func (h *Handler) Update(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	promptID, ok := parsePromptID(c)
+	if !ok {
+		return
+	}
+
+	var req updateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	if req.Name == nil && req.Body == nil && req.IsActive == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "at least one field is required"})
+		return
+	}
+
+	patch := promptdomain.PatchParams{IsActive: req.IsActive}
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "name must not be blank"})
+			return
+		}
+		patch.Name = &name
+	}
+	if req.Body != nil {
+		body := strings.TrimSpace(*req.Body)
+		if body == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "body must not be blank"})
+			return
+		}
+		patch.Body = &body
+	}
+
+	prompt, err := h.useCase.Update(c.Request.Context(), user.ID, promptID, patch)
+	if err != nil {
+		switch {
+		case errors.Is(err, promptdomain.ErrForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		case errors.Is(err, promptdomain.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "prompt not found"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update prompt"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, toResponse(prompt))
+}
+
+func (h *Handler) Delete(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	promptID, ok := parsePromptID(c)
+	if !ok {
+		return
+	}
+
+	if err := h.useCase.Delete(c.Request.Context(), user.ID, promptID); err != nil {
+		switch {
+		case errors.Is(err, promptdomain.ErrForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		case errors.Is(err, promptdomain.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "prompt not found"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete prompt"})
+		}
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+func parsePromptID(c *gin.Context) (int64, bool) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid prompt id"})
+		return 0, false
+	}
+	return id, true
+}
+
+func toResponse(prompt *promptdomain.Prompt) response {
+	return response{
+		ID:        prompt.ID,
+		UserID:    prompt.UserID,
+		Name:      prompt.Name,
+		Body:      prompt.Body,
+		IsActive:  prompt.IsActive,
+		IsDefault: prompt.IsDefault,
+		CreatedAt: prompt.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt: prompt.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func RegisterProtectedRoutes(r gin.IRoutes, useCase *promptusecase.UseCase) {
+	NewHandler(useCase).RegisterProtectedRoutes(r)
+}

--- a/backend/internal/feature/prompt/handler/prompts_test.go
+++ b/backend/internal/feature/prompt/handler/prompts_test.go
@@ -1,0 +1,155 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	pg "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/infra/postgres"
+	promptusecase "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/usecase"
+	userdomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/user/domain"
+	"github.com/yoshioka0101/voiceblog/backend/internal/testutil"
+)
+
+const currentUserKey = "currentUser"
+
+func TestCreate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-handler-create", "handler-create@example.com", "Handler Create User")
+	handler := NewHandler(promptusecase.New(pg.NewRepository(db)))
+	recorder := httptest.NewRecorder()
+
+	body := bytes.NewBufferString(`{"name":"  My Prompt  ","body":"  Prompt body  "}`)
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/prompts", body)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set(currentUserKey, &userdomain.User{ID: userID})
+
+	handler.Create(c)
+
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+
+	var got response
+	if err := json.Unmarshal(recorder.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got.Name != "My Prompt" {
+		t.Fatalf("Name = %q", got.Name)
+	}
+	if got.Body != "Prompt body" {
+		t.Fatalf("Body = %q", got.Body)
+	}
+	if !got.IsActive {
+		t.Fatal("expected IsActive = true")
+	}
+	if got.IsDefault {
+		t.Fatal("expected IsDefault = false")
+	}
+}
+
+func TestList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-handler-list", "handler-list@example.com", "Handler List User")
+	otherUserID := testutil.SeedUser(t, db, "google", "sub-handler-list-other", "handler-list-other@example.com", "Handler List Other User")
+	testutil.SeedPrompt(t, db, &userID, "my-active", "visible", true, false)
+	testutil.SeedPrompt(t, db, &userID, "my-inactive", "hidden", false, false)
+	testutil.SeedPrompt(t, db, &otherUserID, "other-active", "hidden", true, false)
+
+	handler := NewHandler(promptusecase.New(pg.NewRepository(db)))
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/prompts", nil)
+	c.Set(currentUserKey, &userdomain.User{ID: userID})
+
+	handler.List(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var got []response
+	if err := json.Unmarshal(recorder.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	var foundSystem bool
+	var foundMine bool
+	for _, prompt := range got {
+		switch prompt.Name {
+		case "ブログ記事作成（標準）":
+			foundSystem = true
+		case "my-active":
+			foundMine = true
+		case "my-inactive", "other-active":
+			t.Fatalf("unexpected prompt in list: %q", prompt.Name)
+		}
+	}
+
+	if !foundSystem {
+		t.Fatal("expected seeded system prompt in list")
+	}
+	if !foundMine {
+		t.Fatal("expected active user prompt in list")
+	}
+}
+
+func TestUpdate_ForbiddenForSystemPrompt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-handler-update", "handler-update@example.com", "Handler Update User")
+	systemPromptID := testutil.SeedPrompt(t, db, nil, "system-readonly", "body", true, true)
+	handler := NewHandler(promptusecase.New(pg.NewRepository(db)))
+	recorder := httptest.NewRecorder()
+
+	body := bytes.NewBufferString(`{"name":"updated"}`)
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPatch, "/prompts/1", body)
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = gin.Params{{Key: "id", Value: "1"}}
+	c.Set(currentUserKey, &userdomain.User{ID: userID})
+	c.Params[0].Value = strconvFormatInt(systemPromptID)
+
+	handler.Update(c)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusForbidden, recorder.Body.String())
+	}
+}
+
+func TestDelete_ForbiddenForOtherUsersPrompt(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-handler-delete", "handler-delete@example.com", "Handler Delete User")
+	otherUserID := testutil.SeedUser(t, db, "google", "sub-handler-delete-other", "handler-delete-other@example.com", "Handler Delete Other User")
+	otherPromptID := testutil.SeedPrompt(t, db, &otherUserID, "other", "body", true, false)
+	handler := NewHandler(promptusecase.New(pg.NewRepository(db)))
+	recorder := httptest.NewRecorder()
+
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodDelete, "/prompts/1", nil)
+	c.Params = gin.Params{{Key: "id", Value: strconvFormatInt(otherPromptID)}}
+	c.Set(currentUserKey, &userdomain.User{ID: userID})
+
+	handler.Delete(c)
+
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body=%s", recorder.Code, http.StatusForbidden, recorder.Body.String())
+	}
+}
+
+func strconvFormatInt(v int64) string {
+	return strconv.FormatInt(v, 10)
+}

--- a/backend/internal/feature/prompt/infra/postgres/repository.go
+++ b/backend/internal/feature/prompt/infra/postgres/repository.go
@@ -1,0 +1,155 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	promptdomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/domain"
+)
+
+type Repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+func (r *Repository) ListVisibleByUserID(ctx context.Context, userID int64) ([]*promptdomain.Prompt, error) {
+	const query = `
+		SELECT id, user_id, name, body, is_active, is_default, created_at, updated_at
+		FROM prompts
+		WHERE is_active = TRUE
+		  AND (user_id IS NULL OR user_id = $1)
+		ORDER BY is_default DESC, CASE WHEN user_id IS NULL THEN 0 ELSE 1 END, created_at DESC, id DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list prompts: %w", err)
+	}
+	defer rows.Close()
+
+	var prompts []*promptdomain.Prompt
+	for rows.Next() {
+		prompt, err := scanPrompt(rows.Scan)
+		if err != nil {
+			return nil, fmt.Errorf("scan prompt: %w", err)
+		}
+		prompts = append(prompts, prompt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate prompts: %w", err)
+	}
+
+	return prompts, nil
+}
+
+func (r *Repository) Create(ctx context.Context, params promptdomain.CreateParams) (*promptdomain.Prompt, error) {
+	const query = `
+		INSERT INTO prompts (user_id, name, body, is_active, is_default)
+		VALUES ($1, $2, $3, $4, FALSE)
+		RETURNING id, user_id, name, body, is_active, is_default, created_at, updated_at
+	`
+
+	row := r.db.QueryRowContext(ctx, query, params.UserID, params.Name, params.Body, params.IsActive)
+
+	prompt, err := scanPrompt(row.Scan)
+	if err != nil {
+		return nil, fmt.Errorf("insert prompt: %w", err)
+	}
+
+	return prompt, nil
+}
+
+func (r *Repository) FindByID(ctx context.Context, id int64) (*promptdomain.Prompt, error) {
+	const query = `
+		SELECT id, user_id, name, body, is_active, is_default, created_at, updated_at
+		FROM prompts
+		WHERE id = $1
+	`
+
+	row := r.db.QueryRowContext(ctx, query, id)
+
+	prompt, err := scanPrompt(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, promptdomain.ErrNotFound
+		}
+		return nil, fmt.Errorf("find prompt: %w", err)
+	}
+
+	return prompt, nil
+}
+
+func (r *Repository) Update(ctx context.Context, params promptdomain.UpdateParams) (*promptdomain.Prompt, error) {
+	const query = `
+		UPDATE prompts
+		SET name = $2,
+		    body = $3,
+		    is_active = $4,
+		    updated_at = NOW()
+		WHERE id = $1
+		RETURNING id, user_id, name, body, is_active, is_default, created_at, updated_at
+	`
+
+	row := r.db.QueryRowContext(ctx, query, params.ID, params.Name, params.Body, params.IsActive)
+
+	prompt, err := scanPrompt(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, promptdomain.ErrNotFound
+		}
+		return nil, fmt.Errorf("update prompt: %w", err)
+	}
+
+	return prompt, nil
+}
+
+func (r *Repository) Delete(ctx context.Context, id int64) error {
+	const query = `
+		DELETE FROM prompts
+		WHERE id = $1
+	`
+
+	result, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("delete prompt: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete prompt rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return promptdomain.ErrNotFound
+	}
+
+	return nil
+}
+
+func scanPrompt(scan func(dest ...any) error) (*promptdomain.Prompt, error) {
+	var prompt promptdomain.Prompt
+	var userID sql.NullInt64
+
+	if err := scan(
+		&prompt.ID,
+		&userID,
+		&prompt.Name,
+		&prompt.Body,
+		&prompt.IsActive,
+		&prompt.IsDefault,
+		&prompt.CreatedAt,
+		&prompt.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if userID.Valid {
+		prompt.UserID = &userID.Int64
+	}
+
+	return &prompt, nil
+}

--- a/backend/internal/feature/prompt/infra/postgres/repository_test.go
+++ b/backend/internal/feature/prompt/infra/postgres/repository_test.go
@@ -1,0 +1,143 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	promptdomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/domain"
+	pg "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/infra/postgres"
+	"github.com/yoshioka0101/voiceblog/backend/internal/testutil"
+)
+
+func TestCreate(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-create-prompt", "create-prompt@example.com", "Create Prompt User")
+	repo := pg.NewRepository(db)
+
+	prompt, err := repo.Create(context.Background(), promptdomain.CreateParams{
+		UserID:   userID,
+		Name:     "My Prompt",
+		Body:     "Summarize this transcript.",
+		IsActive: true,
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if prompt.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+	if prompt.UserID == nil || *prompt.UserID != userID {
+		t.Fatalf("UserID = %v, want %d", prompt.UserID, userID)
+	}
+	if prompt.Name != "My Prompt" {
+		t.Fatalf("Name = %q", prompt.Name)
+	}
+	if prompt.Body != "Summarize this transcript." {
+		t.Fatalf("Body = %q", prompt.Body)
+	}
+	if !prompt.IsActive {
+		t.Fatal("expected IsActive = true")
+	}
+	if prompt.IsDefault {
+		t.Fatal("expected IsDefault = false")
+	}
+}
+
+func TestListVisibleByUserID(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	targetUserID := testutil.SeedUser(t, db, "google", "sub-prompt-list-target", "prompt-target@example.com", "Prompt Target User")
+	otherUserID := testutil.SeedUser(t, db, "google", "sub-prompt-list-other", "prompt-other@example.com", "Prompt Other User")
+	repo := pg.NewRepository(db)
+
+	testutil.SeedPrompt(t, db, &targetUserID, "target-active", "visible", true, false)
+	testutil.SeedPrompt(t, db, &targetUserID, "target-inactive", "hidden", false, false)
+	testutil.SeedPrompt(t, db, &otherUserID, "other-active", "hidden", true, false)
+
+	prompts, err := repo.ListVisibleByUserID(context.Background(), targetUserID)
+	if err != nil {
+		t.Fatalf("ListVisibleByUserID failed: %v", err)
+	}
+
+	var foundSystem bool
+	var foundTarget bool
+	for _, prompt := range prompts {
+		switch prompt.Name {
+		case "ブログ記事作成（標準）":
+			foundSystem = true
+			if prompt.UserID != nil {
+				t.Fatalf("system prompt UserID = %v, want nil", prompt.UserID)
+			}
+		case "target-active":
+			foundTarget = true
+			if prompt.UserID == nil || *prompt.UserID != targetUserID {
+				t.Fatalf("target-active UserID = %v, want %d", prompt.UserID, targetUserID)
+			}
+		case "target-inactive", "other-active":
+			t.Fatalf("unexpected prompt in result: %q", prompt.Name)
+		}
+	}
+
+	if !foundSystem {
+		t.Fatal("expected seeded system prompt in result")
+	}
+	if !foundTarget {
+		t.Fatal("expected active user prompt in result")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-prompt-update", "prompt-update@example.com", "Prompt Update User")
+	repo := pg.NewRepository(db)
+
+	promptID := testutil.SeedPrompt(t, db, &userID, "old", "old body", true, false)
+
+	updated, err := repo.Update(context.Background(), promptdomain.UpdateParams{
+		ID:       promptID,
+		Name:     "new",
+		Body:     "new body",
+		IsActive: false,
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	if updated.Name != "new" {
+		t.Fatalf("Name = %q", updated.Name)
+	}
+	if updated.Body != "new body" {
+		t.Fatalf("Body = %q", updated.Body)
+	}
+	if updated.IsActive {
+		t.Fatal("expected IsActive = false")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-prompt-delete", "prompt-delete@example.com", "Prompt Delete User")
+	repo := pg.NewRepository(db)
+
+	promptID := testutil.SeedPrompt(t, db, &userID, "delete-me", "body", true, false)
+
+	if err := repo.Delete(context.Background(), promptID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	_, err := repo.FindByID(context.Background(), promptID)
+	if !errors.Is(err, promptdomain.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFindByID_NotFound(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	repo := pg.NewRepository(db)
+
+	_, err := repo.FindByID(context.Background(), 99999)
+	if !errors.Is(err, promptdomain.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/backend/internal/feature/prompt/module.go
+++ b/backend/internal/feature/prompt/module.go
@@ -1,0 +1,23 @@
+package prompt
+
+import (
+	"database/sql"
+
+	"github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/domain"
+	"github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/infra/postgres"
+	"github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/usecase"
+)
+
+type Feature struct {
+	Repository domain.Repository
+	UseCase    *usecase.UseCase
+}
+
+func New(db *sql.DB) *Feature {
+	repo := postgres.NewRepository(db)
+
+	return &Feature{
+		Repository: repo,
+		UseCase:    usecase.New(repo),
+	}
+}

--- a/backend/internal/feature/prompt/routes.go
+++ b/backend/internal/feature/prompt/routes.go
@@ -1,0 +1,11 @@
+package prompt
+
+import (
+	"github.com/gin-gonic/gin"
+
+	featurehandler "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/handler"
+)
+
+func RegisterProtectedRoutes(r gin.IRoutes, feature *Feature) {
+	featurehandler.RegisterProtectedRoutes(r, feature.UseCase)
+}

--- a/backend/internal/feature/prompt/usecase/usecase.go
+++ b/backend/internal/feature/prompt/usecase/usecase.go
@@ -1,0 +1,63 @@
+package usecase
+
+import (
+	"context"
+
+	promptdomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt/domain"
+)
+
+type UseCase struct {
+	repo promptdomain.Repository
+}
+
+func New(repo promptdomain.Repository) *UseCase {
+	return &UseCase{repo: repo}
+}
+
+func (uc *UseCase) ListVisibleByUserID(ctx context.Context, userID int64) ([]*promptdomain.Prompt, error) {
+	return uc.repo.ListVisibleByUserID(ctx, userID)
+}
+
+func (uc *UseCase) Create(ctx context.Context, params promptdomain.CreateParams) (*promptdomain.Prompt, error) {
+	return uc.repo.Create(ctx, params)
+}
+
+func (uc *UseCase) Update(ctx context.Context, userID, promptID int64, params promptdomain.PatchParams) (*promptdomain.Prompt, error) {
+	prompt, err := uc.repo.FindByID(ctx, promptID)
+	if err != nil {
+		return nil, err
+	}
+	if !prompt.OwnedBy(userID) {
+		return nil, promptdomain.ErrForbidden
+	}
+
+	updateParams := promptdomain.UpdateParams{
+		ID:       prompt.ID,
+		Name:     prompt.Name,
+		Body:     prompt.Body,
+		IsActive: prompt.IsActive,
+	}
+	if params.Name != nil {
+		updateParams.Name = *params.Name
+	}
+	if params.Body != nil {
+		updateParams.Body = *params.Body
+	}
+	if params.IsActive != nil {
+		updateParams.IsActive = *params.IsActive
+	}
+
+	return uc.repo.Update(ctx, updateParams)
+}
+
+func (uc *UseCase) Delete(ctx context.Context, userID, promptID int64) error {
+	prompt, err := uc.repo.FindByID(ctx, promptID)
+	if err != nil {
+		return err
+	}
+	if !prompt.OwnedBy(userID) {
+		return promptdomain.ErrForbidden
+	}
+
+	return uc.repo.Delete(ctx, promptID)
+}

--- a/backend/internal/feature/transcription/domain/repository.go
+++ b/backend/internal/feature/transcription/domain/repository.go
@@ -1,0 +1,9 @@
+package domain
+
+import "context"
+
+type Repository interface {
+	Create(ctx context.Context, params CreateParams) (*Transcription, error)
+	ListByUserID(ctx context.Context, userID int64) ([]*Transcription, error)
+	FindByID(ctx context.Context, id int64) (*Transcription, error)
+}

--- a/backend/internal/feature/transcription/domain/transcription.go
+++ b/backend/internal/feature/transcription/domain/transcription.go
@@ -1,0 +1,27 @@
+package domain
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+var (
+	ErrNotFound  = errors.New("transcription not found")
+	ErrForbidden = errors.New("transcription forbidden")
+)
+
+type Transcription struct {
+	ID           int64
+	UserID       int64
+	FullText     string
+	SegmentsJSON json.RawMessage
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type CreateParams struct {
+	UserID       int64
+	FullText     string
+	SegmentsJSON json.RawMessage
+}

--- a/backend/internal/feature/transcription/handler/transcriptions.go
+++ b/backend/internal/feature/transcription/handler/transcriptions.go
@@ -1,0 +1,138 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	transcriptiondomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/domain"
+	transcriptionusecase "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/usecase"
+	"github.com/yoshioka0101/voiceblog/backend/internal/handler/middleware"
+)
+
+type Handler struct {
+	useCase *transcriptionusecase.UseCase
+}
+
+type createRequest struct {
+	FullText     string          `json:"full_text" binding:"required"`
+	SegmentsJSON json.RawMessage `json:"segments_json"`
+}
+
+type response struct {
+	ID           int64           `json:"id"`
+	UserID       int64           `json:"user_id"`
+	FullText     string          `json:"full_text"`
+	SegmentsJSON json.RawMessage `json:"segments_json"`
+	CreatedAt    string          `json:"created_at"`
+	UpdatedAt    string          `json:"updated_at"`
+}
+
+func NewHandler(useCase *transcriptionusecase.UseCase) *Handler {
+	return &Handler{useCase: useCase}
+}
+
+func (h *Handler) RegisterProtectedRoutes(r gin.IRoutes) {
+	r.POST("/transcriptions", h.Create)
+	r.GET("/transcriptions", h.List)
+	r.GET("/transcriptions/:id", h.Get)
+}
+
+func (h *Handler) Create(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req createRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	if len(req.SegmentsJSON) == 0 || !json.Valid(req.SegmentsJSON) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "segments_json must be valid JSON"})
+		return
+	}
+
+	transcription, err := h.useCase.Create(c.Request.Context(), transcriptiondomain.CreateParams{
+		UserID:       user.ID,
+		FullText:     req.FullText,
+		SegmentsJSON: req.SegmentsJSON,
+	})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create transcription"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, toResponse(transcription))
+}
+
+func (h *Handler) List(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	transcriptions, err := h.useCase.ListByUserID(c.Request.Context(), user.ID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list transcriptions"})
+		return
+	}
+
+	responses := make([]response, 0, len(transcriptions))
+	for _, transcription := range transcriptions {
+		responses = append(responses, toResponse(transcription))
+	}
+
+	c.JSON(http.StatusOK, responses)
+}
+
+func (h *Handler) Get(c *gin.Context) {
+	user, ok := middleware.CurrentUser(c)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid transcription id"})
+		return
+	}
+
+	transcription, err := h.useCase.FindByID(c.Request.Context(), user.ID, id)
+	if err != nil {
+		switch {
+		case errors.Is(err, transcriptiondomain.ErrForbidden):
+			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
+		case errors.Is(err, transcriptiondomain.ErrNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "transcription not found"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get transcription"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, toResponse(transcription))
+}
+
+func toResponse(transcription *transcriptiondomain.Transcription) response {
+	return response{
+		ID:           transcription.ID,
+		UserID:       transcription.UserID,
+		FullText:     transcription.FullText,
+		SegmentsJSON: transcription.SegmentsJSON,
+		CreatedAt:    transcription.CreatedAt.UTC().Format(time.RFC3339),
+		UpdatedAt:    transcription.UpdatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func RegisterProtectedRoutes(r gin.IRoutes, useCase *transcriptionusecase.UseCase) {
+	NewHandler(useCase).RegisterProtectedRoutes(r)
+}

--- a/backend/internal/feature/transcription/infra/postgres/repository.go
+++ b/backend/internal/feature/transcription/infra/postgres/repository.go
@@ -1,0 +1,105 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	transcriptiondomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/domain"
+)
+
+type Repository struct {
+	db *sql.DB
+}
+
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+func (r *Repository) Create(ctx context.Context, params transcriptiondomain.CreateParams) (*transcriptiondomain.Transcription, error) {
+	const query = `
+		INSERT INTO transcriptions (user_id, full_text, segments_json)
+		VALUES ($1, $2, $3)
+		RETURNING id, user_id, full_text, segments_json, created_at, updated_at
+	`
+
+	row := r.db.QueryRowContext(ctx, query, params.UserID, params.FullText, []byte(params.SegmentsJSON))
+
+	transcription, err := scanTranscription(row.Scan)
+	if err != nil {
+		return nil, fmt.Errorf("insert transcription: %w", err)
+	}
+
+	return transcription, nil
+}
+
+func (r *Repository) ListByUserID(ctx context.Context, userID int64) ([]*transcriptiondomain.Transcription, error) {
+	const query = `
+		SELECT id, user_id, full_text, segments_json, created_at, updated_at
+		FROM transcriptions
+		WHERE user_id = $1
+		ORDER BY created_at DESC, id DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list transcriptions: %w", err)
+	}
+	defer rows.Close()
+
+	var transcriptions []*transcriptiondomain.Transcription
+	for rows.Next() {
+		transcription, err := scanTranscription(rows.Scan)
+		if err != nil {
+			return nil, fmt.Errorf("scan transcription: %w", err)
+		}
+		transcriptions = append(transcriptions, transcription)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transcriptions: %w", err)
+	}
+
+	return transcriptions, nil
+}
+
+func (r *Repository) FindByID(ctx context.Context, id int64) (*transcriptiondomain.Transcription, error) {
+	const query = `
+		SELECT id, user_id, full_text, segments_json, created_at, updated_at
+		FROM transcriptions
+		WHERE id = $1
+	`
+
+	row := r.db.QueryRowContext(ctx, query, id)
+
+	transcription, err := scanTranscription(row.Scan)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, transcriptiondomain.ErrNotFound
+		}
+		return nil, fmt.Errorf("find transcription: %w", err)
+	}
+
+	return transcription, nil
+}
+
+func scanTranscription(scan func(dest ...any) error) (*transcriptiondomain.Transcription, error) {
+	var transcription transcriptiondomain.Transcription
+	var segments []byte
+
+	if err := scan(
+		&transcription.ID,
+		&transcription.UserID,
+		&transcription.FullText,
+		&segments,
+		&transcription.CreatedAt,
+		&transcription.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	transcription.SegmentsJSON = json.RawMessage(append([]byte(nil), segments...))
+
+	return &transcription, nil
+}

--- a/backend/internal/feature/transcription/infra/postgres/repository_test.go
+++ b/backend/internal/feature/transcription/infra/postgres/repository_test.go
@@ -1,0 +1,119 @@
+package postgres_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	transcriptiondomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/domain"
+	pg "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/infra/postgres"
+	"github.com/yoshioka0101/voiceblog/backend/internal/testutil"
+)
+
+func TestCreate(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-create", "create@example.com", "Create User")
+	repo := pg.NewRepository(db)
+
+	transcription, err := repo.Create(context.Background(), transcriptiondomain.CreateParams{
+		UserID:       userID,
+		FullText:     "hello world",
+		SegmentsJSON: json.RawMessage(`[{"text":"hello world"}]`),
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if transcription.ID == 0 {
+		t.Fatal("expected non-zero ID")
+	}
+	if transcription.UserID != userID {
+		t.Fatalf("UserID = %d, want %d", transcription.UserID, userID)
+	}
+	if transcription.FullText != "hello world" {
+		t.Fatalf("FullText = %q", transcription.FullText)
+	}
+	if string(transcription.SegmentsJSON) != `[{"text":"hello world"}]` {
+		t.Fatalf("SegmentsJSON = %s", string(transcription.SegmentsJSON))
+	}
+}
+
+func TestListByUserID(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	targetUserID := testutil.SeedUser(t, db, "google", "sub-list-target", "target@example.com", "Target User")
+	otherUserID := testutil.SeedUser(t, db, "google", "sub-list-other", "other@example.com", "Other User")
+	repo := pg.NewRepository(db)
+	ctx := context.Background()
+
+	if _, err := repo.Create(ctx, transcriptiondomain.CreateParams{
+		UserID:       targetUserID,
+		FullText:     "target-1",
+		SegmentsJSON: json.RawMessage(`[{"text":"target-1"}]`),
+	}); err != nil {
+		t.Fatalf("Create target-1 failed: %v", err)
+	}
+	if _, err := repo.Create(ctx, transcriptiondomain.CreateParams{
+		UserID:       targetUserID,
+		FullText:     "target-2",
+		SegmentsJSON: json.RawMessage(`[{"text":"target-2"}]`),
+	}); err != nil {
+		t.Fatalf("Create target-2 failed: %v", err)
+	}
+	if _, err := repo.Create(ctx, transcriptiondomain.CreateParams{
+		UserID:       otherUserID,
+		FullText:     "other",
+		SegmentsJSON: json.RawMessage(`[{"text":"other"}]`),
+	}); err != nil {
+		t.Fatalf("Create other failed: %v", err)
+	}
+
+	transcriptions, err := repo.ListByUserID(ctx, targetUserID)
+	if err != nil {
+		t.Fatalf("ListByUserID failed: %v", err)
+	}
+
+	if len(transcriptions) != 2 {
+		t.Fatalf("len(transcriptions) = %d, want 2", len(transcriptions))
+	}
+	for _, transcription := range transcriptions {
+		if transcription.UserID != targetUserID {
+			t.Fatalf("unexpected UserID = %d", transcription.UserID)
+		}
+	}
+}
+
+func TestFindByID(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	userID := testutil.SeedUser(t, db, "google", "sub-find", "find@example.com", "Find User")
+	repo := pg.NewRepository(db)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, transcriptiondomain.CreateParams{
+		UserID:       userID,
+		FullText:     "find me",
+		SegmentsJSON: json.RawMessage(`[{"text":"find me"}]`),
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	found, err := repo.FindByID(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("FindByID failed: %v", err)
+	}
+
+	if found.ID != created.ID {
+		t.Fatalf("ID = %d, want %d", found.ID, created.ID)
+	}
+}
+
+func TestFindByID_NotFound(t *testing.T) {
+	db := testutil.SetupTestDB(t)
+	repo := pg.NewRepository(db)
+
+	_, err := repo.FindByID(context.Background(), 99999)
+	if !errors.Is(err, transcriptiondomain.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}

--- a/backend/internal/feature/transcription/module.go
+++ b/backend/internal/feature/transcription/module.go
@@ -1,0 +1,23 @@
+package transcription
+
+import (
+	"database/sql"
+
+	"github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/domain"
+	"github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/infra/postgres"
+	"github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/usecase"
+)
+
+type Feature struct {
+	Repository domain.Repository
+	UseCase    *usecase.UseCase
+}
+
+func New(db *sql.DB) *Feature {
+	repo := postgres.NewRepository(db)
+
+	return &Feature{
+		Repository: repo,
+		UseCase:    usecase.New(repo),
+	}
+}

--- a/backend/internal/feature/transcription/routes.go
+++ b/backend/internal/feature/transcription/routes.go
@@ -1,0 +1,11 @@
+package transcription
+
+import (
+	"github.com/gin-gonic/gin"
+
+	featurehandler "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/handler"
+)
+
+func RegisterProtectedRoutes(r gin.IRoutes, feature *Feature) {
+	featurehandler.RegisterProtectedRoutes(r, feature.UseCase)
+}

--- a/backend/internal/feature/transcription/usecase/usecase.go
+++ b/backend/internal/feature/transcription/usecase/usecase.go
@@ -1,0 +1,34 @@
+package usecase
+
+import (
+	"context"
+
+	transcriptiondomain "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription/domain"
+)
+
+type UseCase struct {
+	repo transcriptiondomain.Repository
+}
+
+func New(repo transcriptiondomain.Repository) *UseCase {
+	return &UseCase{repo: repo}
+}
+
+func (uc *UseCase) Create(ctx context.Context, params transcriptiondomain.CreateParams) (*transcriptiondomain.Transcription, error) {
+	return uc.repo.Create(ctx, params)
+}
+
+func (uc *UseCase) ListByUserID(ctx context.Context, userID int64) ([]*transcriptiondomain.Transcription, error) {
+	return uc.repo.ListByUserID(ctx, userID)
+}
+
+func (uc *UseCase) FindByID(ctx context.Context, userID, transcriptionID int64) (*transcriptiondomain.Transcription, error) {
+	transcription, err := uc.repo.FindByID(ctx, transcriptionID)
+	if err != nil {
+		return nil, err
+	}
+	if transcription.UserID != userID {
+		return nil, transcriptiondomain.ErrForbidden
+	}
+	return transcription, nil
+}

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/yoshioka0101/voiceblog/backend/internal/di"
 	"github.com/yoshioka0101/voiceblog/backend/internal/feature/health"
+	transcriptionfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription"
 	userfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/user"
 	"github.com/yoshioka0101/voiceblog/backend/internal/handler/middleware"
 )
@@ -15,4 +16,5 @@ func RegisterRoutes(r *gin.Engine, c *di.Container) {
 	authGroup := r.Group("/")
 	authGroup.Use(middleware.Auth(c.Auth.UseCase))
 	userfeature.RegisterProtectedRoutes(authGroup)
+	transcriptionfeature.RegisterProtectedRoutes(authGroup, c.Transcription)
 }

--- a/backend/internal/handler/router.go
+++ b/backend/internal/handler/router.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/yoshioka0101/voiceblog/backend/internal/di"
 	"github.com/yoshioka0101/voiceblog/backend/internal/feature/health"
+	promptfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/prompt"
 	transcriptionfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/transcription"
 	userfeature "github.com/yoshioka0101/voiceblog/backend/internal/feature/user"
 	"github.com/yoshioka0101/voiceblog/backend/internal/handler/middleware"
@@ -15,6 +16,7 @@ func RegisterRoutes(r *gin.Engine, c *di.Container) {
 
 	authGroup := r.Group("/")
 	authGroup.Use(middleware.Auth(c.Auth.UseCase))
+	promptfeature.RegisterProtectedRoutes(authGroup, c.Prompt)
 	userfeature.RegisterProtectedRoutes(authGroup)
 	transcriptionfeature.RegisterProtectedRoutes(authGroup, c.Transcription)
 }

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -109,6 +109,28 @@ func SeedUser(t *testing.T, db *sql.DB, provider, subject, email, name string) i
 	return id
 }
 
+func SeedPrompt(t *testing.T, db *sql.DB, userID *int64, name, body string, isActive, isDefault bool) int64 {
+	t.Helper()
+
+	const query = `
+		INSERT INTO prompts (user_id, name, body, is_active, is_default)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id
+	`
+
+	var id int64
+	var nullableUserID any
+	if userID != nil {
+		nullableUserID = *userID
+	}
+
+	if err := db.QueryRowContext(context.Background(), query, nullableUserID, name, body, isActive, isDefault).Scan(&id); err != nil {
+		t.Fatalf("failed to seed prompt: %v", err)
+	}
+
+	return id
+}
+
 func MustFindMigrationPath(name string) string {
 	return filepath.Join(projectRoot(), "migrations", "migrations", name)
 }

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -3,8 +3,10 @@ package testutil
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"testing"
 	"time"
 
@@ -19,17 +21,25 @@ import (
 // テスト終了時にコンテナは自動破棄される。
 func SetupTestDB(t *testing.T) *sql.DB {
 	t.Helper()
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 
 	ctx := context.Background()
 
-	migrationPath := filepath.Join(projectRoot(), "migrations", "migrations", "20260320_create_users.sql")
+	migrationPaths, err := filepath.Glob(filepath.Join(projectRoot(), "migrations", "migrations", "*.sql"))
+	if err != nil {
+		t.Fatalf("failed to list migrations: %v", err)
+	}
+	if len(migrationPaths) == 0 {
+		t.Fatal("no migrations found")
+	}
+	sort.Strings(migrationPaths)
 
 	pgContainer, err := postgres.Run(ctx,
 		"postgres:16-alpine",
 		postgres.WithDatabase("voiceblog_test"),
 		postgres.WithUsername("test"),
 		postgres.WithPassword("test"),
-		postgres.WithInitScripts(migrationPath),
+		postgres.WithInitScripts(migrationPaths...),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
@@ -80,4 +90,29 @@ func projectRoot() string {
 	// filename = .../voiceblog/backend/internal/testutil/db.go
 	// backend の親がプロジェクトルート
 	return filepath.Join(filepath.Dir(filename), "..", "..", "..")
+}
+
+func SeedUser(t *testing.T, db *sql.DB, provider, subject, email, name string) int64 {
+	t.Helper()
+
+	const query = `
+		INSERT INTO users (auth_provider, auth_subject, email, name)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id
+	`
+
+	var id int64
+	if err := db.QueryRowContext(context.Background(), query, provider, subject, email, name).Scan(&id); err != nil {
+		t.Fatalf("failed to seed user: %v", err)
+	}
+
+	return id
+}
+
+func MustFindMigrationPath(name string) string {
+	return filepath.Join(projectRoot(), "migrations", "migrations", name)
+}
+
+func FormatDSN(host string, port int, dbName string) string {
+	return fmt.Sprintf("postgres://test:test@%s:%d/%s?sslmode=disable", host, port, dbName)
 }

--- a/backend/openapi/components/schemas/prompt.yaml
+++ b/backend/openapi/components/schemas/prompt.yaml
@@ -1,0 +1,29 @@
+type: object
+properties:
+  id:
+    type: integer
+  user_id:
+    type: integer
+    nullable: true
+  name:
+    type: string
+  body:
+    type: string
+  is_active:
+    type: boolean
+  is_default:
+    type: boolean
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time
+required:
+  - id
+  - name
+  - body
+  - is_active
+  - is_default
+  - created_at
+  - updated_at

--- a/backend/openapi/components/schemas/prompt_create_request.yaml
+++ b/backend/openapi/components/schemas/prompt_create_request.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  name:
+    type: string
+  body:
+    type: string
+  is_active:
+    type: boolean
+required:
+  - name
+  - body

--- a/backend/openapi/components/schemas/prompt_update_request.yaml
+++ b/backend/openapi/components/schemas/prompt_update_request.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  name:
+    type: string
+  body:
+    type: string
+  is_active:
+    type: boolean

--- a/backend/openapi/components/schemas/transcription.yaml
+++ b/backend/openapi/components/schemas/transcription.yaml
@@ -1,0 +1,26 @@
+type: object
+properties:
+  id:
+    type: integer
+  user_id:
+    type: integer
+  full_text:
+    type: string
+  segments_json:
+    type: array
+    items:
+      type: object
+      additionalProperties: true
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time
+required:
+  - id
+  - user_id
+  - full_text
+  - segments_json
+  - created_at
+  - updated_at

--- a/backend/openapi/components/schemas/transcription_create_request.yaml
+++ b/backend/openapi/components/schemas/transcription_create_request.yaml
@@ -1,0 +1,12 @@
+type: object
+properties:
+  full_text:
+    type: string
+  segments_json:
+    type: array
+    items:
+      type: object
+      additionalProperties: true
+required:
+  - full_text
+  - segments_json

--- a/backend/openapi/gen-openapi.yaml
+++ b/backend/openapi/gen-openapi.yaml
@@ -14,10 +14,197 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/health'
+  /me:
+    get:
+      summary: Current user
+      operationId: getMe
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/user'
+        '401':
+          description: Unauthorized
+  /prompts:
+    get:
+      summary: List current user's prompts and system prompts
+      operationId: listPrompts
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/prompt'
+        '401':
+          description: Unauthorized
+    post:
+      summary: Create prompt
+      operationId: createPrompt
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/prompt_create_request'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/prompt'
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+  /prompts/{id}:
+    patch:
+      summary: Update a user prompt
+      operationId: updatePrompt
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/prompt_update_request'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/prompt'
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+    delete:
+      summary: Delete a user prompt
+      operationId: deletePrompt
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
+  /transcriptions:
+    get:
+      summary: List current user's transcriptions
+      operationId: listTranscriptions
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/transcription'
+        '401':
+          description: Unauthorized
+    post:
+      summary: Create transcription
+      operationId: createTranscription
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/transcription_create_request'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/transcription'
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+  /transcriptions/{id}:
+    get:
+      summary: Get transcription detail
+      operationId: getTranscription
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/transcription'
+        '400':
+          description: Bad Request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Not Found
 components:
   schemas:
     HealthResponse:
       $ref: '#/components/schemas/health'
+    Prompt:
+      $ref: '#/components/schemas/prompt'
+    PromptCreateRequest:
+      $ref: '#/components/schemas/prompt_create_request'
+    PromptUpdateRequest:
+      $ref: '#/components/schemas/prompt_update_request'
+    Transcription:
+      $ref: '#/components/schemas/transcription'
+    TranscriptionCreateRequest:
+      $ref: '#/components/schemas/transcription_create_request'
+    User:
+      $ref: '#/components/schemas/user'
     health:
       type: object
       properties:
@@ -26,3 +213,113 @@ components:
           example: ok
       required:
         - status
+    user:
+      type: object
+      properties:
+        id:
+          type: integer
+        email:
+          type: string
+        name:
+          type: string
+        auth_provider:
+          type: string
+      required:
+        - id
+        - auth_provider
+    prompt:
+      type: object
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+          nullable: true
+        name:
+          type: string
+        body:
+          type: string
+        is_active:
+          type: boolean
+        is_default:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - name
+        - body
+        - is_active
+        - is_default
+        - created_at
+        - updated_at
+    prompt_create_request:
+      type: object
+      properties:
+        name:
+          type: string
+        body:
+          type: string
+        is_active:
+          type: boolean
+      required:
+        - name
+        - body
+    prompt_update_request:
+      type: object
+      properties:
+        name:
+          type: string
+        body:
+          type: string
+        is_active:
+          type: boolean
+    transcription:
+      type: object
+      properties:
+        id:
+          type: integer
+        user_id:
+          type: integer
+        full_text:
+          type: string
+        segments_json:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - user_id
+        - full_text
+        - segments_json
+        - created_at
+        - updated_at
+    transcription_create_request:
+      type: object
+      properties:
+        full_text:
+          type: string
+        segments_json:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+      required:
+        - full_text
+        - segments_json
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -7,10 +7,18 @@ paths:
     $ref: ./paths/health.yaml
   /me:
     $ref: ./paths/me.yaml
+  /transcriptions:
+    $ref: ./paths/transcriptions.yaml
+  /transcriptions/{id}:
+    $ref: ./paths/transcription_by_id.yaml
 components:
   schemas:
     HealthResponse:
       $ref: ./components/schemas/health.yaml
+    Transcription:
+      $ref: ./components/schemas/transcription.yaml
+    TranscriptionCreateRequest:
+      $ref: ./components/schemas/transcription_create_request.yaml
     User:
       $ref: ./components/schemas/user.yaml
   securitySchemes:

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -7,6 +7,10 @@ paths:
     $ref: ./paths/health.yaml
   /me:
     $ref: ./paths/me.yaml
+  /prompts:
+    $ref: ./paths/prompts.yaml
+  /prompts/{id}:
+    $ref: ./paths/prompt_by_id.yaml
   /transcriptions:
     $ref: ./paths/transcriptions.yaml
   /transcriptions/{id}:
@@ -15,6 +19,12 @@ components:
   schemas:
     HealthResponse:
       $ref: ./components/schemas/health.yaml
+    Prompt:
+      $ref: ./components/schemas/prompt.yaml
+    PromptCreateRequest:
+      $ref: ./components/schemas/prompt_create_request.yaml
+    PromptUpdateRequest:
+      $ref: ./components/schemas/prompt_update_request.yaml
     Transcription:
       $ref: ./components/schemas/transcription.yaml
     TranscriptionCreateRequest:

--- a/backend/openapi/paths/prompt_by_id.yaml
+++ b/backend/openapi/paths/prompt_by_id.yaml
@@ -1,0 +1,54 @@
+patch:
+  summary: Update a user prompt
+  operationId: updatePrompt
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/prompt_update_request.yaml
+  responses:
+    "200":
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/prompt.yaml
+    "400":
+      description: Bad Request
+    "401":
+      description: Unauthorized
+    "403":
+      description: Forbidden
+    "404":
+      description: Not Found
+delete:
+  summary: Delete a user prompt
+  operationId: deletePrompt
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    "204":
+      description: No Content
+    "400":
+      description: Bad Request
+    "401":
+      description: Unauthorized
+    "403":
+      description: Forbidden
+    "404":
+      description: Not Found

--- a/backend/openapi/paths/prompts.yaml
+++ b/backend/openapi/paths/prompts.yaml
@@ -1,0 +1,38 @@
+get:
+  summary: List current user's prompts and system prompts
+  operationId: listPrompts
+  security:
+    - bearerAuth: []
+  responses:
+    "200":
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/prompt.yaml
+    "401":
+      description: Unauthorized
+post:
+  summary: Create prompt
+  operationId: createPrompt
+  security:
+    - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/prompt_create_request.yaml
+  responses:
+    "201":
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/prompt.yaml
+    "400":
+      description: Bad Request
+    "401":
+      description: Unauthorized

--- a/backend/openapi/paths/transcription_by_id.yaml
+++ b/backend/openapi/paths/transcription_by_id.yaml
@@ -1,0 +1,26 @@
+get:
+  summary: Get transcription detail
+  operationId: getTranscription
+  security:
+    - bearerAuth: []
+  parameters:
+    - in: path
+      name: id
+      required: true
+      schema:
+        type: integer
+  responses:
+    "200":
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/transcription.yaml
+    "400":
+      description: Bad Request
+    "401":
+      description: Unauthorized
+    "403":
+      description: Forbidden
+    "404":
+      description: Not Found

--- a/backend/openapi/paths/transcriptions.yaml
+++ b/backend/openapi/paths/transcriptions.yaml
@@ -1,0 +1,38 @@
+get:
+  summary: List current user's transcriptions
+  operationId: listTranscriptions
+  security:
+    - bearerAuth: []
+  responses:
+    "200":
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: ../components/schemas/transcription.yaml
+    "401":
+      description: Unauthorized
+post:
+  summary: Create transcription
+  operationId: createTranscription
+  security:
+    - bearerAuth: []
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../components/schemas/transcription_create_request.yaml
+  responses:
+    "201":
+      description: Created
+      content:
+        application/json:
+          schema:
+            $ref: ../components/schemas/transcription.yaml
+    "400":
+      description: Bad Request
+    "401":
+      description: Unauthorized

--- a/migrations/migrations/20260322_create_transcriptions.sql
+++ b/migrations/migrations/20260322_create_transcriptions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE transcriptions (
+    id            BIGSERIAL   PRIMARY KEY,
+    user_id       BIGINT      NOT NULL REFERENCES users(id),
+    full_text     TEXT        NOT NULL,
+    segments_json JSONB       NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX transcriptions_user_id_created_at_desc_idx
+    ON transcriptions (user_id, created_at DESC);

--- a/migrations/migrations/20260323_create_prompts.sql
+++ b/migrations/migrations/20260323_create_prompts.sql
@@ -1,0 +1,22 @@
+CREATE TABLE prompts (
+    id         BIGSERIAL    PRIMARY KEY,
+    user_id    BIGINT       REFERENCES users(id),
+    name       VARCHAR(255) NOT NULL,
+    body       TEXT         NOT NULL,
+    is_active  BOOLEAN      NOT NULL DEFAULT TRUE,
+    is_default BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX prompts_user_id_is_active_created_at_desc_idx
+    ON prompts (user_id, is_active, created_at DESC);
+
+INSERT INTO prompts (user_id, name, body, is_active, is_default)
+VALUES (
+    NULL,
+    'ブログ記事作成（標準）',
+    '以下の文字起こしをもとに、読みやすい日本語のブログ記事を作成してください。タイトルと導入文も含めてください。',
+    TRUE,
+    TRUE
+);

--- a/migrations/migrations/atlas.sum
+++ b/migrations/migrations/atlas.sum
@@ -1,2 +1,4 @@
-h1:lRZ76u/vufMg4EgxUsPGpYMxWLIsQzetN82GMK3INnk=
+h1:vlrIOA/6jDgLRQr9BKN85vH0F3rV9lqbSLFbdlM9t6E=
 20260320_create_users.sql h1:44cCn0Vt9PCV6PcM+3vQmxlsiaZY+tRkPiVvk5LG9es=
+20260322_create_transcriptions.sql h1:/Q9cidQhuAq+HzLDK985L1He8f1SXJ7Q5i7lq56UXuc=
+20260323_create_prompts.sql h1:898xppypf/BheW8CCGTbP4vRJui1f++eGDVH4kqP79s=

--- a/migrations/schema.hcl
+++ b/migrations/schema.hcl
@@ -35,3 +35,40 @@ table "users" {
     columns = [column.auth_provider, column.auth_subject]
   }
 }
+
+table "transcriptions" {
+  schema = schema.voiceblog
+  column "id" {
+    type = bigserial
+  }
+  column "user_id" {
+    type = bigint
+  }
+  column "full_text" {
+    type = text
+  }
+  column "segments_json" {
+    type = jsonb
+  }
+  column "created_at" {
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  column "updated_at" {
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "transcriptions_user_id_fkey" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  index "transcriptions_user_id_created_at_desc_idx" {
+    columns = [column.user_id, column.created_at]
+    desc    = [false, true]
+  }
+}

--- a/migrations/schema.hcl
+++ b/migrations/schema.hcl
@@ -72,3 +72,49 @@ table "transcriptions" {
     desc    = [false, true]
   }
 }
+
+table "prompts" {
+  schema = schema.voiceblog
+  column "id" {
+    type = bigserial
+  }
+  column "user_id" {
+    type = bigint
+    null = true
+  }
+  column "name" {
+    type = varchar(255)
+  }
+  column "body" {
+    type = text
+  }
+  column "is_active" {
+    type    = boolean
+    default = true
+  }
+  column "is_default" {
+    type    = boolean
+    default = false
+  }
+  column "created_at" {
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  column "updated_at" {
+    type    = timestamptz
+    default = sql("NOW()")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  foreign_key "prompts_user_id_fkey" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_update   = NO_ACTION
+    on_delete   = NO_ACTION
+  }
+  index "prompts_user_id_is_active_created_at_desc_idx" {
+    columns = [column.user_id, column.is_active, column.created_at]
+    desc    = [false, false, true]
+  }
+}


### PR DESCRIPTION
Closes #29

## Summary
- prompts テーブルと初期システム prompt の seed を追加
- prompt feature を追加し、一覧・作成・更新・削除 API と所有権チェックを実装
- Repository / handler テストと OpenAPI 定義・bundle を更新

## Verification
- go build ./...
- ./.bin/golangci-lint run ./...
- go test ./...
- ./.bin/golangci-lint run ./...

## Notes
- この PR は origin/issues/28 の上に積んだ stacked PR のため、base branch は issues/28
- go test ./... は既存の httptest.NewServer を使うテストがローカル port bind を必要とするため、sandbox 外で再実行
